### PR TITLE
Fix joining of seed hosts to be compatible with python 3.5

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -487,7 +487,7 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
 
     if seed_hosts is not None:
         debug1('seed_hosts: %r\n' % seed_hosts)
-        mux.send(0, ssnet.CMD_HOST_REQ, b'\n'.join(seed_hosts))
+        mux.send(0, ssnet.CMD_HOST_REQ, str.encode('\n'.join(seed_hosts)))
 
     while 1:
         rv = serverproc.poll()


### PR DESCRIPTION
Hi,

This patch fixes an issue with python 3.5 when using the seed-hosts command option.
The construct b'\n.join(list) does not return bytes in python 3
replacing with str.encode('\n'.join(list)) workes in python 2 & python 3
